### PR TITLE
Bump httpclient from 4.2.5 to 4.5.13 in /hbc-core

### DIFF
--- a/hbc-core/pom.xml
+++ b/hbc-core/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.2.5</version>
+      <version>4.5.13</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Bumps httpclient from 4.2.5 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>